### PR TITLE
Rename NewsListing to Features and HowTo

### DIFF
--- a/src/components/features/index.js
+++ b/src/components/features/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import './_features.scss';
 
-const NewsListing = props =>
+const Features = props =>
   (<section className="features" id="features">
     <div className="container">
       <div className="row">
@@ -24,4 +24,4 @@ const NewsListing = props =>
     </div>
   </section>);
 
-export default NewsListing;
+export default Features;

--- a/src/components/how-to/index.js
+++ b/src/components/how-to/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import './_how-to.scss';
 
-const NewsListing = props =>
+const HowTo = props =>
   (<section className="howto" id="howto">
     <div className="container">
       <div className="row">
@@ -24,4 +24,4 @@ const NewsListing = props =>
     </div>
   </section>);
 
-export default NewsListing;
+export default HowTo;


### PR DESCRIPTION
These two components are named "NewsListing" which looks confusing because the "News" is not longer present in the app.

This PR proposes to rename their declaration to something more intuitive.

New names match the usage of these components in [pages/index.js](https://github.com/PrototypeInteractive/gatsby-react-boilerplate/blob/master/src/pages/index.js).

